### PR TITLE
changed weak self to unowned

### DIFF
--- a/AKSideMenu/AKSideMenu.swift
+++ b/AKSideMenu/AKSideMenu.swift
@@ -386,33 +386,33 @@ import UIKit
         self.rightMenuVisible = false
         self.contentButton.removeFromSuperview()
 
-        let animationBlock = { [weak self] in
-            self!.contentViewContainer.transform = CGAffineTransform.identity
-            self!.contentViewContainer.frame = self!.view.bounds
-            if self!.scaleMenuView {
-                self!.menuViewContainer.transform = self!.menuViewControllerTransformation!
+        let animationBlock = { [unowned self] in
+            self.contentViewContainer.transform = CGAffineTransform.identity
+            self.contentViewContainer.frame = self.view.bounds
+            if self.scaleMenuView {
+                self.menuViewContainer.transform = self.menuViewControllerTransformation!
             }
-            if self!.fadeMenuView {
-                self!.menuViewContainer.alpha = 0
+            if self.fadeMenuView {
+                self.menuViewContainer.alpha = 0
             }
-            self!.contentViewContainer.alpha = 1
+            self.contentViewContainer.alpha = 1
 
-            if self!.scaleBackgroundImageView {
-                self!.backgroundImageView!.transform = self!.backgroundTransformMakeScale()
+            if self.scaleBackgroundImageView {
+                self.backgroundImageView!.transform = self.backgroundTransformMakeScale()
 
             }
-            if self!.parallaxEnabled {
-                for effect in self!.contentViewContainer.motionEffects {
-                    self!.contentViewContainer.removeMotionEffect(effect)
+            if self.parallaxEnabled {
+                for effect in self.contentViewContainer.motionEffects {
+                    self.contentViewContainer.removeMotionEffect(effect)
                 }
             }
         }
 
-        let completionBlock = { [weak self] in
+        let completionBlock = { [unowned self] in
             visibleMenuViewController.endAppearanceTransition()
-            self!.statusBarNeedsAppearanceUpdate()
-            if self!.visible == false {
-                self!.delegate?.sideMenu?(self!, didHideMenuViewController:rightMenuVisible ? self!.rightMenuViewController! : self!.leftMenuViewController!)
+            self.statusBarNeedsAppearanceUpdate()
+            if self.visible == false {
+                self.delegate?.sideMenu?(self, didHideMenuViewController:rightMenuVisible ? self.rightMenuViewController! : self.leftMenuViewController!)
             }
         }
 


### PR DESCRIPTION
###### Fixes issue #.
- [x] This pull request follows the coding standards

updating from `self weak` to `unowned weak`, if you're forcing unwrapping the weak self and you're sure it will never be nil, I think it's better to use the unowned self instead.