### PR TITLE
Avoid crashing when notifing delegates

### DIFF
--- a/AKSideMenu/AKSideMenu.swift
+++ b/AKSideMenu/AKSideMenu.swift
@@ -618,13 +618,13 @@ import UIKit
 
             if !self.sideMenuDelegateNotify {
                 if point.x > 0 {
-                    if !self.visible {
-                        self.delegate?.sideMenu?(self, willShowMenuViewController:self.leftMenuViewController!)
+                    if let leftMenuViewController = self.leftMenuViewController, !self.visible {
+                        self.delegate?.sideMenu?(self, willShowMenuViewController:leftMenuViewController)
                     }
                 }
                 if point.x < 0 {
-                    if !self.visible {
-                        self.delegate?.sideMenu?(self, willShowMenuViewController:self.rightMenuViewController!)
+                    if let rightMenuViewController = self.rightMenuViewController, !self.visible {
+                        self.delegate?.sideMenu?(self, willShowMenuViewController:rightMenuViewController)
                     }
                 }
                 self.sideMenuDelegateNotify = true


### PR DESCRIPTION
When panning from a direction (left, right) while there are no menu view controller assigned to that direction, the delegation call `func sideMenu(_ sideMenu: AKSideMenu, willShowMenuViewController menuViewController: UIViewController)` will crash on a forced unwrapped optional menu view controller which really was nil. It may be better to return at the point where the changes are made, but there is too much code for me to evaluate the consequences of doing so.

###### Fixes issue #.
- [x] This pull request follows the coding standards

###### This PR changes:
 - 