### PR TITLE
Fix contentViewContainer additionalSafeAreaInset

### DIFF
--- a/Sources/AKSideMenu/AKSideMenu.swift
+++ b/Sources/AKSideMenu/AKSideMenu.swift
@@ -514,10 +514,11 @@ open class AKSideMenu: UIViewController, UIGestureRecognizerDelegate {
                 } else if insets.top < .zero {
                     insets.top = .zero
                 }
-                let bottomSafeArea = self.view.safeAreaLayoutGuide.layoutFrame.maxY
-                if insets.bottom < bottomSafeArea {
+                insets.bottom = self.view.frame.maxY - self.contentViewContainer.frame.maxY
+                let bottomSafeArea = self.view.frame.maxY - self.view.safeAreaLayoutGuide.layoutFrame.maxY
+                if insets.bottom > bottomSafeArea {
                     insets.bottom = bottomSafeArea
-                } else if insets.bottom <= bottomSafeArea {
+                } else if insets.bottom < .zero {
                     insets.bottom = .zero
                 }
                 self.contentViewController?.additionalSafeAreaInsets = insets


### PR DESCRIPTION
Previous fix doesn't work in my project. It sets contentViewController.additionalSafeAreaInsets.bottom to entire screen height minus top safe area inset.

This fix works for all values of contentViewScaleValue and follows logic of setting top safe area inset.